### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,17 @@
-FROM ruby:2.7.0
-RUN apt-get update -y && \
-    apt-get install -y \
-      pandoc=2.2.1-3+b2 \
-      pandoc-citeproc=0.14.3.1-4+b3 \
-      texlive-latex-base=2018.20190227-2 \
-      texlive-fonts-recommended=2018.20190227-2 \
-      texlive-fonts-extra=2018.20190227-2 \
-      texlive-latex-extra=2018.20190227-2 \
-      texlive-bibtex-extra=2018.20190227-2 \
-      librsvg2-bin
+FROM ruby:3.0.2
+
+ENV PANDOC_VERSION="2.16.1"
+
+RUN wget --output-document="/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz" "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz" && \
+    tar xf "pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz" && \
+    ln -s "/pandoc-${PANDOC_VERSION}/bin/pandoc" "/usr/local/bin"
+
+RUN apt update -y && apt install -y \
+    librsvg2-bin=2.50.3+dfsg-1 \
+    texlive-bibtex-extra=2020.20210202-3 \
+    texlive-latex-base=2020.20210202-3 \
+    texlive-latex-extra=2020.20210202-3
+
 ADD ./bin /gen-pdf/bin
 ADD ./lib /gen-pdf/lib
 ADD ./resources /gen-pdf/resources


### PR DESCRIPTION
- update base image to ruby:3.0.2
- update pandoc version to 2.16.1
- install relevant libraries and fix their versions

Tested with the commands below (same as ones in the README):

```
$ docker build -t biohackrxiv/gen-pdf:local -f docker/Dockerfile .
$ docker run --rm -it -v $(pwd):/work -w /work biohackrxiv/gen-pdf:local gen-pdf /work/example/logic
```