### PR TITLE
Add a bit of whitespace (no-break space) around the ORCID icon

### DIFF
--- a/resources/biohackrxiv/latex.template
+++ b/resources/biohackrxiv/latex.template
@@ -383,7 +383,7 @@ $endif$
 % ORCID support
 
 \definecolor{orcidlogocol}{HTML}{A6CE39}
-\newcommand{\orcidlink}[1]{\protect\href{https://orcid.org/#1}{\small\textcolor{orcidlogocol}{\faOrcid}}}
+\newcommand{\orcidlink}[1]{\protect\href{https://orcid.org/#1}{\,\small\textcolor{orcidlogocol}{\faOrcid}\,}}
 
 $if(authors)$
   $for(authors)$


### PR DESCRIPTION
With this patch it looks like this:

![image](https://github.com/user-attachments/assets/58512d7a-1e88-4c5f-b559-4fa3e84e4093)
